### PR TITLE
updated to include stripe info

### DIFF
--- a/tables/advertiser.js
+++ b/tables/advertiser.js
@@ -24,9 +24,19 @@ export const Advertiser = {
       maxLength: 128
     },
     billingInfo: {
-      description: 'Stripe customer token',
-      type: 'string',
-      maxLength: 128
+      description: 'Stripe customer info',
+      type: 'object',
+      properties: {
+        customerId: {
+          description: 'The stripe customer id',
+          type: 'string',
+          maxLength: 128
+        },
+        cardOnFile: {
+          description: 'Whether we have a card on file',
+          type: 'boolean'
+        }
+      }
     },
     adCampaigns: {
       type: 'array',


### PR DESCRIPTION
We're going to store customer id, but also want to easily know without fetching the stripe customer whether they've added payment info (stored CC info)